### PR TITLE
fix(Searchable) Use ::class syntax for hasExtension Versioned check

### DIFF
--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -288,7 +288,7 @@ class Searchable extends DataExtension
     protected function setPublishedStatus($document)
     {
         $isLive = true;
-        if ($this->owner->hasExtension('Versioned')) {
+        if ($this->owner->hasExtension(Versioned::class)) {
             if ($this->owner instanceof SiteTree) {
                 $isLive = $this->owner->isPublished();
             }


### PR DESCRIPTION
Needs the fully qualified class name for the hasExtension check