### PR TITLE
change(ResultList) Use ID and ClassName for objects

### DIFF
--- a/src/ResultList.php
+++ b/src/ResultList.php
@@ -189,7 +189,7 @@ class ResultList extends ViewableData implements SS_List
                         $needed[$type] = array($id);
                         $retrieved[$type] = array();
                     } else {
-                        $needed[$type][] = $item->getId();
+                        $needed[$type][] = $id;
                     }
                 }
 

--- a/src/ResultList.php
+++ b/src/ResultList.php
@@ -42,8 +42,8 @@ class ResultList extends ViewableData implements SS_List
         ));
 
         // update the 'source' param of the query to ensure ID and ClassName are retrieved
-        $source = $query->getParam('_source');
-        if ($source && is_array($source)) {
+        if ($query->hasParam('_source')) {
+            $source = $query->getParam('_source');
             $source[] = 'ID';
             $source[] = 'ClassName';
             $source = array_unique($source);

--- a/src/ResultList.php
+++ b/src/ResultList.php
@@ -41,10 +41,21 @@ class ResultList extends ViewableData implements SS_List
             '_type'
         ));
 
-        $query->setSource([
-            'ID',
-            'ClassName'
-        ]);
+        // update the 'source' param of the query to ensure ID and ClassName are retrieved
+        $source = $query->getParam('_source');
+        if ($source && is_array($source)) {
+            $source[] = 'ID';
+            $source[] = 'ClassName';
+            $source = array_unique($source);
+            
+        } else {
+            $source = [
+                'ID',
+                'ClassName'
+            ];
+        }
+        $query->setSource($source);
+        
 
         //If we are in live reading mode, only return published documents
         if (Versioned::get_reading_mode() == Versioned::DEFAULT_MODE) {

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -144,7 +144,10 @@ class Searchable extends DataExtension
      */
     protected function getSearchableFields()
     {
-        $result = array();
+        $result = array(
+            'ID' => ['type' => 'long'],
+            'ClassName' => ['type' => 'string']
+        );
 
         $fields = array_merge($this->owner->inheritedDatabaseFields(), $this->owner->config()->get('fixed_fields'));
 
@@ -305,8 +308,8 @@ class Searchable extends DataExtension
     public function getElasticaDocument()
     {
         $ownerConfig = $this->owner->config();
-        $document = new Document($this->owner->ID);
-
+        $id = str_replace('\\', '_', $this->owner->getElasticaType()) . '_' . $this->owner->ID;
+        $document = new Document($id);
         $this->setPublishedStatus($document);
 
         $possibleFields = array_merge(


### PR DESCRIPTION
Rather than indexing and mapping the PHP class Type and ID to
_type and _id, swap to using explicit fields ID and ClassName. The _id and
_type fields are deprecated in 6.0, meaning potential collisions in the _id
field if just left as the SS ID. Instead, the _id field is changed
to being a concatenation of something like

`$id = $this->owner->getElasticaType() . '_' . $this->owner->ID;`

The extension to this is that it allows me to subsequently alter the $document->id to include the $stage value also, so that further updates / deletes are done across appropriate stages too. 


https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-type-field.html