### PR TITLE
FIX ElasticaService::define() now allows index to be deleted before (re)defining it again

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+language: php
+
+matrix:
+  include:
+    - php: 5.6
+      env: DB=MYSQL RECIPE_VERSION=1.0.x-dev PHPUNIT_TEST=1 PHPCS_TEST=1
+    - php: 7.0
+      env: DB=MYSQL RECIPE_VERSION=1.2.x-dev PHPUNIT_TEST=1
+    - php: 7.1
+      env: DB=MYSQL RECIPE_VERSION=4.3.x-dev PDO=1 PHPUNIT_COVERAGE_TEST=1
+    - php: 7.2
+      env: DB=PGSQL RECIPE_VERSION=4.4.x-dev PHPUNIT_TEST=1
+    - php: 7.3
+      env: DB=MYSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1
+
+before_script:
+  # Init PHP
+  - phpenv rehash
+  - phpenv config-rm xdebug.ini
+  - export PATH=~/.composer/vendor/bin:$PATH
+  - echo 'memory_limit = 2048M' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+
+  # Install composer
+  - composer validate
+  - if [[ $DB == PGSQL ]]; then composer require --no-update silverstripe/postgresql:2.1.x-dev; fi
+  - composer require --no-update silverstripe/recipe-testing:^1 silverstripe/recipe-cms:"$RECIPE_VERSION"
+  - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
+
+script:
+  - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit; fi
+  - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs src tests; fi
+  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=coverage.xml; fi
+
+after_success:
+  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then bash <(curl -s https://codecov.io/bash) -f coverage.xml -F php; fi

--- a/composer.json
+++ b/composer.json
@@ -36,9 +36,13 @@
         "ruflin/elastica": "~5.3",
         "symbiote/silverstripe-queuedjobs": "~4.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^5.7"
+    },
     "autoload": {
         "psr-4": {
-            "Heyday\\Elastica\\": "src/"
+            "Heyday\\Elastica\\": "src/",
+            "Heyday\\Elastica\\Tests\\": "tests/"
         }
     },
     "extra": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="SilverStripe">
+    <description>CodeSniffer ruleset for SilverStripe coding conventions.</description>
+
+    <!-- base rules are PSR-2 -->
+    <rule ref="PSR2">
+        <!-- Current exclusions -->
+    </rule>
+</ruleset>
+

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,17 @@
+<!--
+Standard module phpunit configuration.
+Requires PHPUnit ^5.7
+-->
+<phpunit bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true">
+    <testsuite name="Default">
+        <directory>tests/</directory>
+    </testsuite>
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src/</directory>
+            <exclude>
+                <directory suffix=".php">tests/</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/ElasticaService.php
+++ b/src/ElasticaService.php
@@ -356,11 +356,18 @@ class ElasticaService
 
     /**
      * Creates the index and the type mappings.
+     *
+     * @param bool $recreate
      * @throws Exception
      */
-    public function define()
+    public function define($recreate = false)
     {
         $index = $this->getIndex();
+
+        if ($index->exists() && $recreate) {
+            // Delete the existing index so it can be recreated from scratch
+            $index->delete();
+        }
 
         if (!$index->exists()) {
             $this->createIndex();

--- a/src/ReindexTask.php
+++ b/src/ReindexTask.php
@@ -3,6 +3,7 @@
 namespace Heyday\Elastica;
 
 use SilverStripe\Control\Director;
+use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Dev\BuildTask;
 
 /**
@@ -30,7 +31,12 @@ class ReindexTask extends BuildTask
     }
 
     /**
-     * @param \SilverStripe\Control\HTTPRequest $request
+     * Defines (creates and defines mappings for) the index and refreshes the index content.
+     *
+     * You can delete the index before recreating it by adding `recreate=1` as a request argument, which can help
+     * when switching mapping types in your DataObject configuration.
+     *
+     * @param HTTPRequest $request
      */
     public function run($request)
     {
@@ -39,7 +45,8 @@ class ReindexTask extends BuildTask
         };
 
         $message('Defining the mappings');
-        $this->service->define();
+        $recreate = (bool) $request->getVar('recreate');
+        $this->service->define($recreate);
 
         $message('Refreshing the index');
         $this->service->refresh();

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -156,7 +156,7 @@ class Searchable extends DataExtension
      */
     public function inheritedDatabaseFields()
     {
-        return $this->owner::getSchema()->fieldSpecs($this->owner->getClassName());
+        return $this->owner->getSchema()->fieldSpecs($this->owner->getClassName());
     }
 
     /**

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -645,7 +645,7 @@ class Searchable extends DataExtension
      * @param $fieldValue
      * @return string
      */
-    protected function formatBoolean($fieldValue): string
+    protected function formatBoolean($fieldValue)
     {
         return boolval($fieldValue) ? 'true' : 'false';
     }

--- a/tests/ElasticaServiceTest.php
+++ b/tests/ElasticaServiceTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Heyday\Elastica\Tests;
+
+use Elastica\Index;
+use Heyday\Elastica\ElasticaService;
+use PHPUnit_Framework_MockObject_MockObject;
+use SilverStripe\Dev\SapphireTest;
+
+class ElasticaServiceTest extends SapphireTest
+{
+    public function testDefineDeletesIndexIfRecreateIsPassed()
+    {
+        /** @var ElasticaService|PHPUnit_Framework_MockObject_MockObject $service */
+        $service = $this->getMockBuilder(ElasticaService::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getIndex', 'createIndex', 'getIndexedClasses'])
+            ->getMock();
+
+        $service->expects($this->once())->method('getIndexedClasses')->willReturn([]);
+
+        /** @var Index|PHPUnit_Framework_MockObject_MockObject $index */
+        $index = $this->createMock(Index::class);
+        $index->expects($this->exactly(2))->method('exists')->willReturnOnConsecutiveCalls(true, false);
+        $index->expects($this->once())->method('delete');
+
+        $service->expects($this->once())->method('getIndex')->willReturn($index);
+        $service->expects($this->once())->method('createIndex');
+
+        $service->define(true);
+    }
+}


### PR DESCRIPTION
This fixes a bug where changing mapping types on a DataObject after the index has been created would result in a fatal error, but allowing you to explicitly delete the index before redefining it again.

Fixes https://github.com/heyday/silverstripe-elastica/issues/19