### PR TITLE
[WIP] (do not merge) - Developing ElasticSearch 7.x support

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Your\Namespace\SpecialPageWithRelatedDataObject:
     -
       RelatedDataObjects:
         type: nested
+        relationClass: App\DataObjects\Tags # Will be pulled from has_many / many_many, but you can specify it here too
 
 Your\Namespace\RelatedDataObject:
   extensions:
@@ -126,11 +127,15 @@ Your\Namespace\Page:
     - Title
     - SomeOtherField
     -
+      TitleAlias:
+        type: text
+        field: Title # You can specify a custom internal field value with 'field'
+    -
       SomeCustomFieldSimple:
-        type: string
+        type: text
     -
       SomeCustomFieldComplicatedConfig:
-        type: string
+        type: text
         index_anayser: nGram_analyser
         search_analyser: whitespace_analyser
         stored: true

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This module supercedes [Symbiote's Elastica Module](https://github.com/symbiote-
 
 ## Compatibility
 
-This release is compatible with all elasticsearch 5.x releases.
+This release should be compatibly with all ElasticSearch 7.0 and above versions. May work with elasticsearch 6.
 This release requires SilverStripe 4.x
 
 If you need to work with an earlier version of elasticsearch (2.x) and SS (3.x), please try the 1.0 release of this module

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -4,10 +4,10 @@ Name: Heyday Elastica Config
 SilverStripe\Core\Injector\Injector:
   Heyday\Elastica\ReindexTask:
     constructor:
-      - %$Heyday\Elastica\ElasticaService
+      - '%$Heyday\Elastica\ElasticaService'
   Heyday\Elastica\Searchable:
     constructor:
-      - %$Heyday\Elastica\ElasticaService
+      - '%$Heyday\Elastica\ElasticaService'
   ManyManyList:
     class: Heyday\Elastica\ManyManyList
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 		"issues": "http://github.com/heyday/silverstripe-elastica/issues"
 	},
 	"require": {
-		"ruflin/elastica": "3.1.0",
+		"ruflin/elastica": "5.3.1",
 		"symbiote/silverstripe-queuedjobs": "~2.10",
 		"php": ">=7.2"
 	},

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 	},
 	"require": {
 		"ruflin/elastica": "5.3.1",
-		"symbiote/silverstripe-queuedjobs": "~2.10",
+		"symbiote/silverstripe-queuedjobs": "~3.1",
 		"php": ">=7.2"
 	},
 	"autoload": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
 	},
 	"require": {
 		"ruflin/elastica": "3.1.0",
-		"symbiote/silverstripe-queuedjobs": "~2.10"
+		"symbiote/silverstripe-queuedjobs": "~2.10",
+		"php": ">=7.2"
 	},
 	"autoload": {
 		"psr-4": { "Heyday\\Elastica\\": "src/" }

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
     "require": {
         "php": ">=7.2",
         "ruflin/elastica": "^7",
+        "elasticsearch/elasticsearch": "~7.3.0",
         "symbiote/silverstripe-queuedjobs": "^4"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,8 @@
     },
     "require": {
         "php": ">=7.2",
-        "ruflin/elastica": "~5.3",
-        "symbiote/silverstripe-queuedjobs": "~4.0"
+        "ruflin/elastica": "^7",
+        "symbiote/silverstripe-queuedjobs": "^4"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7"

--- a/src/ElasticaService.php
+++ b/src/ElasticaService.php
@@ -10,7 +10,7 @@ use Psr\Log\LoggerInterface;
 /**
  * A service used to interact with elastic search.
  */
-class ElasticaService extends \Object
+class ElasticaService extends \SS_Object
 {
 
     /**

--- a/src/Jobs/ReindexAfterWriteJob.php
+++ b/src/Jobs/ReindexAfterWriteJob.php
@@ -21,11 +21,12 @@ class ReindexAfterWriteJob extends AbstractQueuedJob implements QueuedJob
      *
      * get the instance to reindex and the service
      * ReindexAfterWriteJob constructor.
-     * @param int $id
+     * @param int    $id
      * @param string $class
      */
     public function __construct($id = null, $class = null)
     {
+        parent::__construct();
         if ($id) {
             $this->id = $id;
         }
@@ -119,7 +120,7 @@ class ReindexAfterWriteJob extends AbstractQueuedJob implements QueuedJob
     /**
      * Return an array of dependant class names. These are classes that need to be reindexed when an instance of the
      * extended class is updated or when a relationship to it changes.
-     * @return array|\scalar
+     * @return array|mixed
      */
     public function dependentClasses($versionToIndex)
     {

--- a/src/ReindexTask.php
+++ b/src/ReindexTask.php
@@ -27,6 +27,7 @@ class ReindexTask extends BuildTask
      */
     public function __construct(ElasticaService $service)
     {
+        parent::__construct();
         $this->service = $service;
     }
 

--- a/src/ResultList.php
+++ b/src/ResultList.php
@@ -10,6 +10,7 @@ use Elastica\Query;
 use Elastica\Result;
 use Elastica\ResultSet;
 use Exception;
+use LogicException;
 use Psr\Log\LoggerInterface;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObject;
@@ -181,7 +182,10 @@ class ResultList extends ViewableData implements SS_List
 
             if (is_array($found) || $found instanceof ArrayAccess) {
                 foreach ($found as $item) {
-                    $type = $item->getParam(Searchable::TYPE_FIELD);
+                    $type = $item->{Searchable::TYPE_FIELD};
+                    if (empty($type)) {
+                        throw new LogicException("type field not available");
+                    }
                     if (!array_key_exists($type, $needed)) {
                         $needed[$type] = [$item->getId()];
                         $retrieved[$type] = [];
@@ -198,7 +202,10 @@ class ResultList extends ViewableData implements SS_List
 
                 foreach ($found as $item) {
                     // Safeguards against indexed items which might no longer be in the DB
-                    $type = $item->getParam(Searchable::TYPE_FIELD);
+                    $type = $item->{Searchable::TYPE_FIELD};
+                    if (empty($type)) {
+                        throw new LogicException("type field not available");
+                    }
                     $id = $item->getId();
                     if (!isset($retrieved[$type][$id])) {
                         continue;

--- a/src/ResultList.php
+++ b/src/ResultList.php
@@ -47,13 +47,14 @@ class ResultList extends ViewableData implements SS_List
         parent::__construct();
 
         //Optimise the query by just getting back the ids and types
-        $query->setStoredFields(array(
+        $query->setStoredFields([
             '_id',
+            'type',
             'highlight'
-        ));
+        ]);
 
         //If we are in live reading mode, only return published documents
-        if (Versioned::get_reading_mode() == Versioned::DEFAULT_MODE) {
+        if (Versioned::get_stage() == Versioned::LIVE) {
             $publishedFilter = new Query\BoolQuery();
             $publishedFilter->addMust(new Query\Term([Searchable::$published_field => 'true']));
             $query->setPostFilter($publishedFilter);

--- a/src/ResultList.php
+++ b/src/ResultList.php
@@ -28,7 +28,8 @@ class ResultList extends \ViewableData implements \SS_Limitable
         //Optimise the query by just getting back the ids and types
         $query->setFields(array(
             '_id',
-            '_type'
+            '_type',
+            'highlight'
         ));
 
         //If we are in live reading mode, only return published documents
@@ -166,6 +167,7 @@ class ResultList extends \ViewableData implements \SS_Limitable
                     } else {
                         $needed[$type][] = $item->getId();
                     }
+
                 }
 
                 foreach ($needed as $class => $ids) {
@@ -177,6 +179,20 @@ class ResultList extends \ViewableData implements \SS_Limitable
                 foreach ($found as $item) {
                     // Safeguards against indexed items which might no longer be in the DB
                     if (array_key_exists($item->getId(), $retrieved[$item->getType()])) {
+
+                        $highlights = $item->getHighlights();
+                        $highlightsArray = [];
+
+                        foreach ($highlights as $field => $highlight) {
+                            $concatenatedValue = '';
+                            foreach ($highlight as $key => $value) {
+                                $concatenatedValue .= $value;
+                            }
+                            $highlightsArray[$field] = $concatenatedValue;
+                        }
+
+                        //add Highlights property
+                        $retrieved[$item->getType()][$item->getId()]->highlights = new \ArrayData($highlightsArray);
                         $this->resultsArray[] = $retrieved[$item->getType()][$item->getId()];
                     }
                 }

--- a/src/ResultList.php
+++ b/src/ResultList.php
@@ -49,14 +49,14 @@ class ResultList extends ViewableData implements SS_List
         //Optimise the query by just getting back the ids and types
         $query->setStoredFields([
             '_id',
-            'type',
+            Searchable::TYPE_FIELD,
             'highlight'
         ]);
 
         //If we are in live reading mode, only return published documents
         if (Versioned::get_stage() == Versioned::LIVE) {
             $publishedFilter = new Query\BoolQuery();
-            $publishedFilter->addMust(new Query\Term([Searchable::$published_field => 'true']));
+            $publishedFilter->addMust(new Query\Term([Searchable::PUBLISHED_FIELD => 'true']));
             $query->setPostFilter($publishedFilter);
         }
 
@@ -181,7 +181,7 @@ class ResultList extends ViewableData implements SS_List
 
             if (is_array($found) || $found instanceof ArrayAccess) {
                 foreach ($found as $item) {
-                    $type = $item->getParam('type');
+                    $type = $item->getParam(Searchable::TYPE_FIELD);
                     if (!array_key_exists($type, $needed)) {
                         $needed[$type] = [$item->getId()];
                         $retrieved[$type] = [];
@@ -198,7 +198,7 @@ class ResultList extends ViewableData implements SS_List
 
                 foreach ($found as $item) {
                     // Safeguards against indexed items which might no longer be in the DB
-                    $type = $item->getParam('type');
+                    $type = $item->getParam(Searchable::TYPE_FIELD);
                     $id = $item->getId();
                     if (!isset($retrieved[$type][$id])) {
                         continue;

--- a/src/ResultList.php
+++ b/src/ResultList.php
@@ -26,7 +26,7 @@ class ResultList extends \ViewableData implements \SS_Limitable
     public function __construct(Index $index, Query $query, LoggerInterface $logger = null)
     {
         //Optimise the query by just getting back the ids and types
-        $query->setFields(array(
+        $query->setStoredFields(array(
             '_id',
             '_type',
             'highlight'

--- a/src/ResultList.php
+++ b/src/ResultList.php
@@ -14,6 +14,7 @@ use LogicException;
 use Psr\Log\LoggerInterface;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\Limitable;
 use SilverStripe\ORM\Map;
 use SilverStripe\ORM\SS_List;
 use SilverStripe\Versioned\Versioned;
@@ -24,7 +25,7 @@ use Traversable;
 /**
  * A list wrapper around the results from a query. Note that not all operations are implemented.
  */
-class ResultList extends ViewableData implements SS_List
+class ResultList extends ViewableData implements SS_List, Limitable
 {
 
     /**

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -54,10 +54,21 @@ class Searchable extends DataExtension
     ];
 
     /**
+     * ElasticSearch 7.0 compatibility: Use a custom 'type' field instead of deprecated _type
+     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html#_custom_type_field
+     *
+     * @var array
+     * @config
+     */
+    private static $indexed_fields = [
+        'type' => ['type' => 'keyword'],
+    ];
+
+    /**
      * @config
      * @var array
      */
-    private static $exclude_relations = array();
+    private static $exclude_relations = [];
 
     /**
      * @var ElasticaService
@@ -355,8 +366,11 @@ class Searchable extends DataExtension
                 continue;
             }
 
-            // Check field exists on parent
-            if ($this->owner->hasField($fieldName)) {
+            if ($fieldName === 'type') {
+                // Check 'type' field
+                $fieldValues['type'] = $this->getElasticaType();
+            } elseif ($this->owner->hasField($fieldName)) {
+                // Check field exists on parent
                 $params = $this->getExtraFieldParams($fieldName, $params);
                 $fieldValue = $this->formatValue($params, $this->owner->$fieldName);
                 $fieldValues[$fieldName] = $fieldValue;

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -426,7 +426,12 @@ class Searchable extends \DataExtension
     public function onAfterDelete()
     {
         $this->service->remove($this->owner);
-        $this->updateDependentClasses();
+        if ($this->queued) {
+            $reindex = new ReindexAfterWriteJob($this->owner);
+            singleton('QueuedJobService')->queueJob($reindex);
+        } else {
+            $this->updateDependentClasses();
+        }
     }
 
     /**
@@ -434,7 +439,12 @@ class Searchable extends \DataExtension
      */
     public function onAfterManyManyRelationRemove()
     {
-        $this->updateDependentClasses();
+        if ($this->queued) {
+            $reindex = new ReindexAfterWriteJob($this->owner);
+            singleton('QueuedJobService')->queueJob($reindex);
+        } else {
+            $this->updateDependentClasses();
+        }
     }
 
     /**
@@ -442,7 +452,12 @@ class Searchable extends \DataExtension
      */
     public function onAfterManyManyRelationAdd()
     {
-        $this->updateDependentClasses();
+        if ($this->queued) {
+            $reindex = new ReindexAfterWriteJob($this->owner);
+            singleton('QueuedJobService')->queueJob($reindex);
+        } else {
+            $this->updateDependentClasses();
+        }
     }
 
     /**

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -578,7 +578,7 @@ class Searchable extends DataExtension
         // Detect attachment
         if (isset($params['type']) && $params['type'] === 'attachment') {
             /** @var File $file */
-            $file = $this->owner->$fieldName();
+            $file = $this->owner->relField($fieldName);
             if (!$file instanceof File || !$file->exists()) {
                 return [];
             }
@@ -593,7 +593,7 @@ class Searchable extends DataExtension
         }
 
         // Get item from parent
-        $relatedList = $this->owner->$fieldName();
+        $relatedList = $this->owner->relField($fieldName);
         if (!$relatedList) {
             return [];
         }

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -66,6 +66,7 @@ class Searchable extends DataExtension
     private static $indexed_fields = [
         self::TYPE_FIELD      => [
             'type'  => 'keyword',
+            'store' => 'true',
             'field' => 'ElasticaType',
         ],
         self::PUBLISHED_FIELD => [

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -27,6 +27,10 @@ use function is_numeric;
  */
 class Searchable extends DataExtension
 {
+    public const TYPE_FIELD = 'type';
+
+    public const PUBLISHED_FIELD = 'SS_Published';
+
     /**
      * @config
      * @var array
@@ -60,11 +64,11 @@ class Searchable extends DataExtension
      * @config
      */
     private static $indexed_fields = [
-        'type'         => [
+        self::TYPE_FIELD      => [
             'type'  => 'keyword',
             'field' => 'ElasticaType',
         ],
-        'SS_Published' => [
+        self::PUBLISHED_FIELD => [
             'type'  => 'boolean',
             'field' => 'ElasticaPublishedStatus',
         ]


### PR DESCRIPTION
I've made a bunch of updates to support elasticsearch 7:
 - Update dependencies to ruflin / elasticsearch module (only support up to 7.3)
 - Remove dependency on deprecated '_type' field; Add a new virtual `type` field instead for silverstripe classname
 - Clean up ResultList
 - Remove deprecated 'string' type. Use 'text' or 'keyword' where appropriate.
 - Better support for array of values (only worked with text in the past).
 - Support new 'field' option, which lets you map an internal database field or method to an elasticsearch field of a different name (note: Doesn't work with relations)