### PR TITLE
Correct YAML syntax

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -4,10 +4,10 @@ Name: Heyday Elastica Config
 SilverStripe\Core\Injector\Injector:
   Heyday\Elastica\ReindexTask:
     constructor:
-      - %$Heyday\Elastica\ElasticaService
+      - '%$Heyday\Elastica\ElasticaService'
   Heyday\Elastica\Searchable:
     constructor:
-      - %$Heyday\Elastica\ElasticaService
+      - '%$Heyday\Elastica\ElasticaService'
   ManyManyList:
     class: Heyday\Elastica\ManyManyList
 


### PR DESCRIPTION
symfony/yaml now is more strict about YAML syntax, requiring quotes
where a string has reserved characters.

Prevents error on dev/build:

Uncaught Symfony\Component\Yaml\Exception\ParseException: The reserved
indicator "%" cannot start a plain scalar; you need to quote the scalar
at line 4 (near "- %$Heyday\Elastica\ElasticaService").