### PR TITLE
Use ShowInSearch rather than getField()

### DIFF
--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -419,7 +419,7 @@ class Searchable extends DataExtension
             return;
         }
 
-        if (!$versionToIndex->hasField('ShowInSearch') || $versionToIndex->getField('ShowInSearch')) {
+        if (!$versionToIndex->hasField('ShowInSearch') || $versionToIndex->ShowInSearch) {
             $this->service->index($versionToIndex);
         } else {
             $this->service->remove($versionToIndex);
@@ -505,7 +505,7 @@ class Searchable extends DataExtension
 
                 foreach ($list as $object) {
                     if ($object instanceof DataObject && $object->hasExtension(Searchable::class)) {
-                        if (!$object->hasField('ShowInSearch') || $object->getField('ShowInSearch')) {
+                        if (!$object->hasField('ShowInSearch') || $object->ShowInSearch) {
                             $this->service->index($object);
                         } else {
                             $this->service->remove($object);


### PR DESCRIPTION
getField(), unlike hasField(), does not check for the corresponding getter method. This is because getField is itself meant to be called from getter methods. In other words, hasField and getField are not exactly parallel, by design.

This causes any DataObject whose ShowInSearch exists only as a getter to be unconditionally deleted from the index whenever it is saved.

This fix works by replacing the getField call with a reference to ShowInSearch, which will automatically call getShowInSearch.