### PR TITLE
Enable batch processing in ReindexTask

### DIFF
--- a/src/ReindexTask.php
+++ b/src/ReindexTask.php
@@ -50,6 +50,12 @@ class ReindexTask extends BuildTask
             print(Director::is_cli() ? "$content\n" : "<p>$content</p>");
         };
 
+        $withBatch = (bool) $request->getVar('batch');
+        if ($withBatch) {
+            $message('batch processing is enabled to speed up the reindexing process');
+            $this->service->enableBatch();
+        }
+
         $message('Defining the mappings');
         $recreate = (bool) $request->getVar('recreate');
         $this->service->define($recreate);

--- a/src/ReindexTask.php
+++ b/src/ReindexTask.php
@@ -53,7 +53,7 @@ class ReindexTask extends BuildTask
         $withBatch = (bool) $request->getVar('batch');
         if ($withBatch) {
             $message('batch processing is enabled to speed up the reindexing process');
-            $this->service->enableBatch();
+            //$this->service->enableBatch();
         }
 
         $message('Defining the mappings');
@@ -61,6 +61,6 @@ class ReindexTask extends BuildTask
         $this->service->define($recreate);
 
         $message('Refreshing the index');
-        $this->service->refresh();
+        $this->service->refresh($withBatch);
     }
 }


### PR DESCRIPTION
This pull requests adresses https://github.com/WPP-Public/akqa-nz-silverstripe-elastica/issues/47 .
ReindexTask now accepts an optional parameter "batch". It enables batch processing if set to true.